### PR TITLE
Add initial SLES build compatibility

### DIFF
--- a/rpms/pulp-rpm/pulp-rpm.spec
+++ b/rpms/pulp-rpm/pulp-rpm.spec
@@ -1,13 +1,8 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
-%if 0%{?rhel} == 5
 %define pulp_admin 0
 %define pulp_server 0
-%else
-%define pulp_admin 1
-%define pulp_server 1
-%endif
 
 
 # ---- Pulp (rpm) --------------------------------------------------------------
@@ -22,7 +17,7 @@ URL: https://github.com/pulp/pulp_rpm
 Source0: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
-BuildRequires:  python2-devel
+BuildRequires:  python-devel
 BuildRequires:  python-setuptools
 BuildRequires:  rpm-python
 
@@ -266,6 +261,9 @@ A collection of yum plugins supplementing Pulp consumer operations.
 
 
 %changelog
+* Mon Jul 18 2016 Darin Lively <darinlively@gmail.com> 2.8.5-1
+- Added basic SLES build compatibility
+
 * Wed Apr 06 2016 Sean Myers <sean.myers@redhat.com> 2.8.2-1
 - Pulp rebuild
 

--- a/rpms/pulp/pulp.spec
+++ b/rpms/pulp/pulp.spec
@@ -1,17 +1,10 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
-%if 0%{?rhel} == 5
 %define pulp_admin 0
 %define pulp_client_oauth 0
 %define pulp_server 0
 %define pulp_streamer 0
-%else
-%define pulp_admin 1
-%define pulp_client_oauth 1
-%define pulp_server 1
-%define pulp_streamer 1
-%endif
 
 %if %{pulp_server}
 #SELinux
@@ -43,7 +36,7 @@ URL: https://github.com/%{name}/%{name}/
 Source0: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
-BuildRequires: python2-devel
+BuildRequires: python-devel
 BuildRequires: python-setuptools
 # do not include either of these on rhel 5
 %if 0%{?rhel} == 6
@@ -1047,6 +1040,9 @@ Cert-based repo authentication for Pulp
 %endif # End pulp_server if block for repoauth
 
 %changelog
+* Mon Jul 18 2016 Darin Lively <darinlively@gmail.com> 2.8.5-1
+- Added basic SLES build compatibility
+
 * Tue Jun 14 2016 Jeremy Cline <jcline@redhat.com> 2.8.4-2
 - Add python-importlib dependency for pulp-server
 


### PR DESCRIPTION
This combines https://github.com/pulp/pulp/pull/2566 and https://github.com/pulp/pulp_rpm/issues/871 to add basic SLES 11 build support for client packages.
