### PR TITLE
switch to latest version 2.18, added deb support, ssl generation

### DIFF
--- a/dockerfiles/centos/admin-client/rhel-pulp.repo
+++ b/dockerfiles/centos/admin-client/rhel-pulp.repo
@@ -1,18 +1,18 @@
 # Place this file in your /etc/yum.repos.d/ directory
  
-# Version 2.7 Production Releases
+# Version 2.18 Production Releases
 [pulp-v2-stable]
 name=Pulp v2 Production Releases
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/stable/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/stable/2.18/7Server/$basearch/
 enabled=1
 skip_if_unavailable=0
 gpgcheck=1
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 
-# Version 2.7 Beta Builds
+# Version 2.18 Beta Builds
 [pulp-v2-beta]
 name=Pulp v2 Beta Builds
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/beta/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/beta/2.18/7Server/$basearch/
 enabled=0
 skip_if_unavailable=0
 gpgcheck=1
@@ -21,7 +21,7 @@ gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 # Weekly Testing Builds
 [pulp-v2-testing]
 name=Pulp v2 Testing Builds
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/2.18/7Server/$basearch/
 enabled=0
 skip_if_unavailable=1
 gpgcheck=0

--- a/dockerfiles/centos/base/Dockerfile
+++ b/dockerfiles/centos/base/Dockerfile
@@ -6,9 +6,11 @@ ADD rhel-pulp.repo /etc/yum.repos.d/rhel-pulp.repo
 RUN yum install -y epel-release && yum clean all
 
 RUN yum update -y && yum install -y python-qpid python-qpid-qmf pulp-docker-plugins \
-    pulp-python-plugins findutils nmap-ncat qpid-tools && \
+    pulp-deb-plugins python-pulp-deb-common pulp-deb-admin-extensions \
+    pulp-python-plugins findutils nmap-ncat qpid-tools  && \
     yum groupinstall -y pulp-server-qpid && \
     yum clean all
+
 
 # A volume will be mounted here, clobbering the base structure. We keep a copy
 # so it can be copied back over top of that volume.

--- a/dockerfiles/centos/base/rhel-pulp.repo
+++ b/dockerfiles/centos/base/rhel-pulp.repo
@@ -1,18 +1,18 @@
 # Place this file in your /etc/yum.repos.d/ directory
  
-# Version 2.7 Production Releases
+# Version 2.18 Production Releases
 [pulp-v2-stable]
 name=Pulp v2 Production Releases
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/stable/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/stable/2.18/7Server/$basearch/
 enabled=1
 skip_if_unavailable=0
 gpgcheck=1
 gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 
-# Version 2.7 Beta Builds
+# Version 2.18 Beta Builds
 [pulp-v2-beta]
 name=Pulp v2 Beta Builds
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/beta/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/beta/2.18/7Server/$basearch/
 enabled=0
 skip_if_unavailable=0
 gpgcheck=1
@@ -21,7 +21,7 @@ gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2
 # Weekly Testing Builds
 [pulp-v2-testing]
 name=Pulp v2 Testing Builds
-baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/2.7/7Server/$basearch/
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/2.18/7Server/$basearch/
 enabled=0
 skip_if_unavailable=1
 gpgcheck=0

--- a/dockerfiles/centos/base/setup.sh
+++ b/dockerfiles/centos/base/setup.sh
@@ -13,10 +13,30 @@ if [ ! -e /etc/pulp/server.conf ]
 then
     cp -a /var/local/etc_pulp/* /etc/pulp/
 fi
-if [ ! -e /etc/pki/pulp/ca.crt ]
-then
-    cp -a /var/local/etc_pki_pulp/* /etc/pki/pulp/
-fi
+#if [ ! -e /etc/pki/pulp/ca.crt ]
+#then
+#    cp -a /var/local/etc_pki_pulp/* /etc/pki/pulp/
+#fi
+
+#ssl generate certs
+
+country=US
+state=Arizona
+locality=Phoenix
+organization=common
+organizationalunit=IT
+email=pulp-list@redhat.com
+commonname=*.redhat
+
+openssl req \
+    -new \
+    -newkey rsa:4096 \
+    -days 3650 \
+    -nodes \
+    -x509 \
+    -subj "/C=$country/ST=$state/L=$locality/O=$organization/OU=$organizationalunit/CN=$commonname/emailAddress=$email" \
+    -keyout /etc/pki/pulp/ca.key \
+    -out /etc/pki/pulp/ca.crt
 
 # a hacky way of waiting until mongo is done initializing itself. Eventually
 # (probably 2.5.1) pulp-manage-db will do this on its own in a reasonable way.


### PR DESCRIPTION
1. Switch to 2.18 version, because version 2.7 does not support DEB repos at all.
2. Add generation SSL certificates with all necessary variables in setup.sh
3. Tested on Centos with creation rpm and deb repos.